### PR TITLE
Remove muffler instance from manager using message key.

### DIFF
--- a/src/main/java/com/eclecticlogic/whisper/core/Muffler.java
+++ b/src/main/java/com/eclecticlogic/whisper/core/Muffler.java
@@ -28,7 +28,7 @@ import com.eclecticlogic.whisper.spi.Message;
  *
  */
 public class Muffler<E> {
-
+    private final String messageKey;
     private boolean inSuppression;
     private AtomicInteger messagesSinceSuppressionStart = new AtomicInteger();
     private AtomicInteger messagesSinceLastDigest = new AtomicInteger();
@@ -38,7 +38,7 @@ public class Muffler<E> {
     private WhisperManager<E> manager;
 
 
-    public Muffler(WhisperManager<E> manager) {
+    public Muffler(WhisperManager<E> manager, String messageKey) {
         super();
         this.manager = manager;
         queue.setSuppressAfter(manager.getSuppressAfter());
@@ -54,7 +54,7 @@ public class Muffler<E> {
             if (msg != null && msg.getMessageAge() > manager.getSuppressionExpirationTime()) {
                 // Suppression ends
                 inSuppression = false;
-                manager.remove(this);
+                manager.remove(this.messageKey);
                 // Re-attempt to log this.
                 manager.log(message);
             } else {
@@ -94,7 +94,7 @@ public class Muffler<E> {
                 if (m.getMessageAge() > this.manager.getSuppressionExpirationTime()) {
                     // Suppression ends
                     inSuppression = false;
-                    manager.remove(this);
+                    manager.remove(this.messageKey);
                     lastMessage.set(null);
                 } else {
                     // We haven't received any new messages but we are not outside the suppression time either.

--- a/src/main/java/com/eclecticlogic/whisper/core/WhisperManager.java
+++ b/src/main/java/com/eclecticlogic/whisper/core/WhisperManager.java
@@ -81,7 +81,7 @@ public class WhisperManager<E> extends TimerTask {
         String messageKey = message.getCanonicalMessage();
         Muffler<E> muffler = queuesByMessage.get(messageKey);
         if (muffler == null) {
-            muffler = new Muffler<E>(this);
+            muffler = new Muffler<E>(this, messageKey);
             Muffler<E> temp = queuesByMessage.putIfAbsent(messageKey, muffler);
             if (temp != null) {
                 muffler = temp;
@@ -91,8 +91,8 @@ public class WhisperManager<E> extends TimerTask {
     }
 
 
-    public void remove(Muffler<E> muffler) {
-        queuesByMessage.remove(muffler);
+    public void remove(String messageKey) {
+        queuesByMessage.remove(messageKey);
     }
 
 


### PR DESCRIPTION
After the suppression expiration time has been exceeded the digester is not properly removed from the whisper manager.  This results in both the digester and whisper appender being enabled and logging.  The muffler instance needs to be removed from queuesByMessage map by key not value.
